### PR TITLE
Fix closing a tab with middle click

### DIFF
--- a/src/sidebar/tab/tab.js
+++ b/src/sidebar/tab/tab.js
@@ -128,10 +128,8 @@ export default class ContainerTab {
             })
         })
 
-        // use mousedown because click does not fire for middle button
-        // we would have to have an 'a' element in order for it to work
-        this.element.addEventListener("mousedown", (e) => {
-            if (e.which !== 2) return // middle mouse
+        this.element.addEventListener("auxclick", (e) => {
+            if (e.button !== 1) return
             this._removeCloseClick(e)
         })
 


### PR DESCRIPTION
Listening on `mousedown` and filtering by button causes inconsistent
behaviour. For this particular case, on my machine, using the middle
click would either close the tab, reload it or move it to another
container.

https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event