### PR TITLE
fix: await render before scrolling into view

### DIFF
--- a/src/sidebar/containers/contextual.js
+++ b/src/sidebar/containers/contextual.js
@@ -44,11 +44,11 @@ export default class ContextualIdentityContainer extends VerticalContainer {
         return `/assets/contextual-identities/${this.contextualIdentity.icon}.svg#${this.contextualIdentity.color}`
     }
 
-    async render(renderTabs, callback) {
+    async render(renderTabs) {
         this.elements.containerHeader.style.borderLeftColor =
             this.contextualIdentity.colorCode
         this.elements.icon.style.fill = this.contextualIdentity.colorCode
-        super.render(renderTabs, callback)
+        return await super.render(renderTabs)
     }
 
     supportsCookieStore(cookieStoreId) {

--- a/src/sidebar/containers/temporary.js
+++ b/src/sidebar/containers/temporary.js
@@ -46,13 +46,13 @@ export default class TemporaryContainer extends VerticalContainer {
         return `Temporary containers`
     }
 
-    async render(renderTabs, callback) {
+    async render(renderTabs) {
         if (this.cookieStoreIds.length === 0 && !(await isInstalled())) {
             this.element.style.display = "none"
             return
         }
         this.element.style.display = "initial"
-        super.render(renderTabs, callback)
+        return await super.render(renderTabs)
     }
 
     supportsCookieStore(cookieStoreId) {

--- a/src/sidebar/tab/tab.js
+++ b/src/sidebar/tab/tab.js
@@ -166,7 +166,7 @@ export default class ContainerTab {
      */
     scrollIntoView() {
         const box = this.element.getBoundingClientRect()
-        if (box.bottom < 0 || box.top > window.innerHeight) {
+        if (box.top < 0 || box.bottom > window.innerHeight) {
             this.element.scrollIntoView({
                 block: "end",
                 behavior: "auto",


### PR DESCRIPTION
With a lot of tabs (beyond the sidebar height), then creating a new tab, that tab is not scrolled to.

Turns out it's because it tried scrolling to the tab before it had updated the dom (render).

master:
![cts-wo-await-render](https://user-images.githubusercontent.com/60520/146623030-749154ac-f126-4c25-838c-9356f20565ec.gif)

this pr:
![cts-w-await-render](https://user-images.githubusercontent.com/60520/146623041-ed557bfa-ca2d-4b82-98ab-9a4ec3eead98.gif)

