### PR TITLE
Adding a Grey theme

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -83,6 +83,9 @@
     "options_theme_dark": {
         "message": "Dark"
     },
+    "options_theme_grey": {
+        "message": "Grey"
+    },
     "options_theme_light": {
         "message": "Light"
     },

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -83,6 +83,9 @@
     "options_theme_dark": {
         "message": "Donker"
     },
+    "options_theme_grey": {
+        "message": "Grijs"
+    },
     "options_theme_light": {
         "message": "Licht"
     },

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -84,7 +84,7 @@
         "message": "Ciemna"
     },
     "options_theme_grey": {
-        "message": "szary"
+        "message": "Szary"
     },
     "options_theme_light": {
         "message": "Jasna"

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -83,6 +83,9 @@
     "options_theme_dark": {
         "message": "Ciemna"
     },
+    "options_theme_grey": {
+        "message": "szary"
+    },
     "options_theme_light": {
         "message": "Jasna"
     },

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -16,6 +16,7 @@
             <div class="item browser-style">
                 <select id="theme" name="theme">
                     <option value="dark" data-i18n="options_theme_dark">Dark</option>
+                    <option value="grey" data-i18n="options_theme_grey">Grey</option>
                     <option value="light" data-i18n="options_theme_light">Light</option>
                 </select>
                 <label for="theme">

--- a/src/sidebar/style.css
+++ b/src/sidebar/style.css
@@ -52,7 +52,7 @@ body.hide-empty-pinned:not(.tab-dragged) #pinned-tabs[data-tabs-count="0"] {
 
 #pinned-tabs .container-tab {
     flex-basis: 20x;
-    border-bottom: 3px solid var(--color-default-container);
+    border-top: 3px solid var(--color-default-container);
 }
 
 main {

--- a/src/sidebar/tab/tab.js
+++ b/src/sidebar/tab/tab.js
@@ -137,7 +137,7 @@ export default class ContainerTab {
             browser.contextualIdentities
                 .get(this.tab.cookieStoreId)
                 .then((ci) => {
-                    this.elements["link"].style.borderBottomColor = ci.colorCode
+                    this.elements["link"].style.borderTopColor = ci.colorCode
                 })
         }
     }

--- a/src/sidebar/tab/tab.js
+++ b/src/sidebar/tab/tab.js
@@ -137,7 +137,7 @@ export default class ContainerTab {
             browser.contextualIdentities
                 .get(this.tab.cookieStoreId)
                 .then((ci) => {
-                    this.elements["link"].style.borderTopColor = ci.colorCode
+                    this.elements["link"].style.borderColor = ci.colorCode
                 })
         }
     }

--- a/src/sidebar/theme/grey.css
+++ b/src/sidebar/theme/grey.css
@@ -1,0 +1,100 @@
+:root {
+    --font-size: 12px;
+    --color-hover: #2E2E2E;
+    --color-focus: #424242;
+    --color-text: #eee;
+    --color-accent: #555;
+    --color-background: #333;
+    --color-tab-background: #333;
+    --color-container-background: #2B2D30;
+    --color-default-container: #fff;
+    --color-container-border: #222;
+    --color-close: #ccc;
+    --color-icon: #eee;
+}
+.container-header {
+    font-size: 10px;
+    border-left-width: 0.4em;
+}
+.container-header .container-icon {
+    display: none;
+}
+.container-header .container-title {
+    text-transform: uppercase;
+    margin-left: 0.8em;
+    color: #999;
+    padding: 8px 0px;
+}
+.container-header:last-of-type {
+    border-color: green;
+}
+li.container:last-of-type .container-title {
+    visibility: hidden;
+    position: relative;
+}
+li.container:last-of-type .container-title:after {
+    visibility: visible;
+    position: absolute;
+    left: 0;
+    content: "tmp";
+}
+.container-tab-count {
+    padding-left: 0;
+    margin-left: auto;
+    color: #ccc;
+}
+.container-tab-count::before, .container-tab-count::after {
+    content: '';
+}
+.container-actions {
+    margin-left: 0.3em;
+    margin-right: 0.3em;
+}
+.container-actions .container-action {
+    margin: 0;
+    padding: 5px;
+    font-size: 14px;
+}
+.container-tabs {
+    width: 100%;
+    display: block;
+    padding-inline-start: 0;
+}
+.container-tabs .favicon {
+    margin-right: 0.5em;
+    order: 0;
+}
+.container-tab-title {
+    text-transform: lowercase;
+    flex-basis: 100%;
+    color: #999;
+    padding: 5px 0px;
+    order: 2;
+}
+.tab-active .container-tab-title {
+    text-transform: none;
+    color: #fff;
+}
+.container-tab-action--mute {
+    height: 12px;
+    margin: auto 0;
+    filter: grayscale(1) invert(100%);
+    order: 1;
+}
+.tab-pinned .container-tab-action--mute:hover {
+    filter: grayscale(1) invert(0);
+    background: rgba(255,255,255,0.9) !important;
+    opacity: 1;
+}
+:not(.tab-pinned) .container-tab-action--mute:hover {
+    background: rgba(0, 0, 0,0.1);
+}
+.container-tab-close {
+    padding: 0em 0.2em;
+    margin-left: 0.3em;
+    font-size: 14px;
+    order: 3;
+}
+.container-icon[src$=".png"] {
+    filter: invert();
+}


### PR DESCRIPTION
Hi,

I would like to introduce a "Grey" theme, very different from the Dark and Light ones.

![image](https://user-images.githubusercontent.com/45816387/160441079-99bd9a03-4000-4542-a5f4-e64ff59726f8.png)

If you want to get the same visual outside the sidebar :
- I use Firefox under Linux with a borderless i3wm, and a sober dark/grey theme for the system : [vimix-dark-doder](https://github.com/vinceliuice/vimix-gtk-themes)
- I also use @maciekmm's tricks to hide the Tabs bar and the sidebar header.

This pull request also introduces a modification to the border of the pinned tabs, switching from a bottom to top border, for all themes (because there is a change to a JS injection).
