### PR TITLE
feat: wip: holding control allows highlighting tabs

### DIFF
--- a/src/sidebar/containers/contextual.js
+++ b/src/sidebar/containers/contextual.js
@@ -113,11 +113,6 @@ export default class ContextualIdentityContainer extends VerticalContainer {
         })
     }
 
-    refresh(contextualIdentity) {
-        this.contextualIdentity = contextualIdentity
-        this.render(false)
-    }
-
     async _queryTabs() {
         return await browser.tabs.query({
             currentWindow: true,

--- a/src/sidebar/containers/pinned.js
+++ b/src/sidebar/containers/pinned.js
@@ -23,22 +23,18 @@ export default class PinnedTabsContainer extends AbstractTabContainer {
     }
 
     _handleTabPinned(tabId, change, tab) {
-        if (!tab.pinned) {
-            this.removeTab(tabId)
-        } else {
-            this.render(true)
-        }
+        this.render(true)
     }
 
     async render(updateTabs) {
-        super.render(updateTabs)
+        await super.render(updateTabs)
         if (updateTabs) {
             let tabs = await browser.tabs.query({
                 currentWindow: true,
                 pinned: true,
             })
             this.renderTabs(this.element, tabs)
-            this.render(false)
+            await this.render(false)
         }
     }
 

--- a/src/sidebar/containers/vertical.js
+++ b/src/sidebar/containers/vertical.js
@@ -72,8 +72,8 @@ export default class VerticalContainer extends AbstractTabContainer {
             if (tab.url !== "about:newtab") {
                 tabInfo.url = tab.url
             }
-            await this._actionNewTab(tabInfo)
             await browser.tabs.remove(tabId)
+            await this._actionNewTab(tabInfo)
         }
     }
 
@@ -99,11 +99,7 @@ export default class VerticalContainer extends AbstractTabContainer {
     }
 
     _handleTabPinned(tabId, change, tab) {
-        if (tab.pinned) {
-            this.removeTab(tabId)
-        } else {
-            this.render(true)
-        }
+        this.render(true)
     }
 
     async _actionNewTab(options) {}

--- a/src/sidebar/style.css
+++ b/src/sidebar/style.css
@@ -170,7 +170,9 @@ body:not(.wrap-titles) .container-tab-title, .container-title {
 }
 
 .tab-active,
-.tab-active:hover {
+.tab-active:hover,
+.tab-highlighted,
+.tab-highlighted:hover {
     background: var(--color-focus)
 }
 


### PR DESCRIPTION
Preliminary highlight/select feature using Ctrl key.

Missing features:
- [ ] Context menus that act on highlighted tabs
- [ ] Moving highlighted tabs 
    - [ ] between windows
    - [ ] between containers
    - [ ] within container
    - [ ] mixed mode (between and within container)

